### PR TITLE
Add support for terminated postcodes API

### DIFF
--- a/MarkEmbling.PostcodesIO/IPostcodesIOClient.cs
+++ b/MarkEmbling.PostcodesIO/IPostcodesIOClient.cs
@@ -30,6 +30,9 @@ namespace MarkEmbling.PostcodesIO {
 
         OutwardCodeResult OutwardCodeLookup(string outcode);
 
+        TerminatedPostcodeResult Terminated(string postcode);
+        Task<TerminatedPostcodeResult> TerminatedAsync(string postcode);
+
         /*
         IEnumerable<OutwardCodeResult> OutwardCodeLookupLatLon(ReverseGeocodeQuery query);
         IEnumerable<PostcodeResult> NearestOutwardCode(string outcode, int? limit = null, int? radius = null);

--- a/MarkEmbling.PostcodesIO/MarkEmbling.PostcodesIO.csproj
+++ b/MarkEmbling.PostcodesIO/MarkEmbling.PostcodesIO.csproj
@@ -60,6 +60,7 @@
     <Compile Include="IPostcodesIOClient.cs" />
     <Compile Include="Exceptions\PostcodesIOEmptyResponseException.cs" />
     <Compile Include="Results\OutwardCodeResult.cs" />
+    <Compile Include="Results\TerminatedPostcodeResult.cs" />
     <Compile Include="Results\PostcodeResult.cs" />
     <Compile Include="PostcodesIOClient.cs" />
     <Compile Include="Exceptions\PostcodesIOApiException.cs" />

--- a/MarkEmbling.PostcodesIO/PostcodesIOClient.cs
+++ b/MarkEmbling.PostcodesIO/PostcodesIOClient.cs
@@ -152,6 +152,18 @@ namespace MarkEmbling.PostcodesIO {
             return ExecuteAsync<List<PostcodeResult>>(request).ContinueWith(t => t.Result as IEnumerable<PostcodeResult>, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
+        public TerminatedPostcodeResult Terminated(string postcode)
+        {
+            var request = CreateTerminatedRequest(postcode);
+            return Execute<TerminatedPostcodeResult>(request);
+        }
+
+        public Task<TerminatedPostcodeResult> TerminatedAsync(string postcode)
+        {
+            var request = CreateTerminatedRequest(postcode);
+            return ExecuteAsync<TerminatedPostcodeResult>(request);
+        }
+
         private static RestRequest CreateBulkLookupRequest(IEnumerable<string> postcodes)
         {
             var request = new RestRequest("postcodes", Method.POST)
@@ -225,6 +237,11 @@ namespace MarkEmbling.PostcodesIO {
             if (limit.HasValue) request.AddParameter("limit", limit);
             if (radius.HasValue) request.AddParameter("radius", radius);
             return request;
+        }
+
+        private static RestRequest CreateTerminatedRequest(string postcode)
+        {
+            return new RestRequest(string.Format("terminated_postcodes/{0}", postcode), Method.GET);
         }
     }
 }

--- a/MarkEmbling.PostcodesIO/Results/TerminatedPostcodeResult.cs
+++ b/MarkEmbling.PostcodesIO/Results/TerminatedPostcodeResult.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace MarkEmbling.PostcodesIO.Results {
+    [Serializable]
+    public class TerminatedPostcodeResult
+    {
+        public string Postcode { get; set; }
+        public int YearTerminated { get; set; }
+        public int MonthTerminated { get; set; }
+        public double Longitude { get; set; }
+        public double Latitude { get; set; }
+    }
+}


### PR DESCRIPTION
This allows querying of postcode information for terminated postcodes, which are postcodes that are no longer valid.