### PR TITLE
Added optional proxy server parameter to configure proxy within Execute/ExecuteAsync clients

### DIFF
--- a/src/MarkEmbling.PostcodesIO/PostcodesIOClient.cs
+++ b/src/MarkEmbling.PostcodesIO/PostcodesIOClient.cs
@@ -14,8 +14,8 @@ namespace MarkEmbling.PostcodesIO
         private readonly string _proxyServerUrl;
 
         public PostcodesIOClient(string endpoint = "https://api.postcodes.io", string proxyServerUrl = null) {
-            _proxyServerUrl = proxyServerUrl;
             _endpoint = endpoint;
+            _proxyServerUrl = proxyServerUrl;
         }
 
         private T Execute<T>(RestRequest request) where T : new() {
@@ -23,8 +23,7 @@ namespace MarkEmbling.PostcodesIO
 
             if (!string.IsNullOrEmpty(_proxyServerUrl))
             {
-                WebProxy proxy = new WebProxy(_proxyServerUrl, true);
-                client.Proxy = proxy;
+                client.Proxy = new WebProxy(_proxyServerUrl, true);
                 client.Proxy.Credentials = CredentialCache.DefaultCredentials;
             }
 
@@ -44,8 +43,7 @@ namespace MarkEmbling.PostcodesIO
 
             if (!string.IsNullOrEmpty(_proxyServerUrl))
             {
-                WebProxy proxy = new WebProxy(_proxyServerUrl, true);
-                client.Proxy = proxy;
+                client.Proxy = new WebProxy(_proxyServerUrl, true);
                 client.Proxy.Credentials = CredentialCache.DefaultCredentials;
             }
 

--- a/src/MarkEmbling.PostcodesIO/PostcodesIOClient.cs
+++ b/src/MarkEmbling.PostcodesIO/PostcodesIOClient.cs
@@ -4,19 +4,30 @@ using MarkEmbling.PostcodesIO.Results;
 using RestSharp;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace MarkEmbling.PostcodesIO
 {
     public class PostcodesIOClient : IPostcodesIOClient {
         private readonly string _endpoint;
+        private readonly string _proxyServerUrl;
 
-        public PostcodesIOClient(string endpoint = "https://api.postcodes.io") {
+        public PostcodesIOClient(string endpoint = "https://api.postcodes.io", string proxyServerUrl = null) {
+            _proxyServerUrl = proxyServerUrl;
             _endpoint = endpoint;
         }
 
         private T Execute<T>(RestRequest request) where T : new() {
             var client = new RestClient {BaseUrl = new Uri(_endpoint)};
+
+            if (!string.IsNullOrEmpty(_proxyServerUrl))
+            {
+                WebProxy proxy = new WebProxy(_proxyServerUrl, true);
+                client.Proxy = proxy;
+                client.Proxy.Credentials = CredentialCache.DefaultCredentials;
+            }
+
             var response = client.Execute<RawResult<T>>(request);
 
             if (response.ErrorException != null) 
@@ -30,6 +41,14 @@ namespace MarkEmbling.PostcodesIO
         private async Task<T> ExecuteAsync<T>(RestRequest request) where T : new()
         {
             var client = new RestClient { BaseUrl = new Uri(_endpoint) };
+
+            if (!string.IsNullOrEmpty(_proxyServerUrl))
+            {
+                WebProxy proxy = new WebProxy(_proxyServerUrl, true);
+                client.Proxy = proxy;
+                client.Proxy.Credentials = CredentialCache.DefaultCredentials;
+            }
+
             var response = await client.ExecuteTaskAsync<RawResult<T>>(request).ConfigureAwait(false);
 
             if (response.ErrorException != null)


### PR DESCRIPTION
Allows a proxy to be configured by exposing an optional proxy server URL parameter.

Fixes #14